### PR TITLE
Update install scripts

### DIFF
--- a/install
+++ b/install
@@ -1,1 +1,1 @@
-eval "$(wget -qO- https://raw.githubusercontent.com/basecamp/omakub/master/boot.sh)"
+eval "$(wget -qO- https://raw.githubusercontent.com/basecamp/omakub/stable/boot.sh)"

--- a/install-dev
+++ b/install-dev
@@ -1,1 +1,2 @@
-eval "$(wget -qO- https://raw.githubusercontent.com/basecamp/omakub/master/boot-dev.sh)"
+OMAKUB_REF=master
+eval "$(wget -qO- https://raw.githubusercontent.com/basecamp/omakub/master/boot.sh)"


### PR DESCRIPTION
This PR leverages the changes from:
- https://github.com/basecamp/omakub/pull/187

and additionally updates the `install` script to fetch the `stable` branch's `boot.sh` script (which means we won't need to ensure the `master` branch's `boot.sh` script remains compatible with the `stable` branch).